### PR TITLE
Update Ruby version.

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,8 +3,7 @@ name: enterprise-script-service
 up:
   - xcode_clt
   - ruby:
-      package: shopify/shopify/shopify-ruby
-      version: 2.2.3p172-shopify
+      version: 2.4.3
   - bundler
   - submodules
 


### PR DESCRIPTION
2.2.3p172-shopify no longer exists; I've changed the version to match core.