### PR TITLE
[PoC] Support latest mruby

### DIFF
--- a/ext/enterprise_script_service/data.cpp
+++ b/ext/enterprise_script_service/data.cpp
@@ -153,7 +153,7 @@ void emit_ruby_as_msgpack_rec(me_mruby_engine &engine, mrb_value ruby_value, out
       auto *hash = RHASH(ruby_value);
 
       if (hash) {
-        int64_t size = mrb_fixnum(mrb_funcall_argv(engine.state, ruby_value, mrb_intern_lit(engine.state, "size"), 0, NULL));
+        int64_t size = mrb_hash_size(engine.state, ruby_value);
         if (size > UINT32_MAX) {
           throw fatal_error(status_code::structure_too_deep);
         }

--- a/ext/enterprise_script_service/data.cpp
+++ b/ext/enterprise_script_service/data.cpp
@@ -155,9 +155,7 @@ void emit_ruby_as_msgpack_rec(me_mruby_engine &engine, mrb_value ruby_value, out
       if (hash) {
         int64_t size = mrb_fixnum(mrb_funcall_argv(engine.state, ruby_value, mrb_intern_lit(engine.state, "size"), 0, NULL));
         if (size > UINT32_MAX) {
-          me_mruby_engine *engine;
           throw fatal_error(status_code::structure_too_deep);
-          out_packer *packer;
         }
         packer.pack_map((uint32_t) size);
 

--- a/ext/enterprise_script_service/data.cpp
+++ b/ext/enterprise_script_service/data.cpp
@@ -153,6 +153,14 @@ void emit_ruby_as_msgpack_rec(me_mruby_engine &engine, mrb_value ruby_value, out
       auto *hash = RHASH(ruby_value);
 
       if (hash) {
+        int64_t size = mrb_fixnum(mrb_funcall_argv(engine.state, ruby_value, mrb_intern_lit(engine.state, "size"), 0, NULL));
+        if (size > UINT32_MAX) {
+          me_mruby_engine *engine;
+          throw fatal_error(status_code::structure_too_deep);
+          out_packer *packer;
+        }
+        packer.pack_map((uint32_t) size);
+
         struct loop_context {
           me_mruby_engine *engine;
           out_packer *packer;


### PR DESCRIPTION
mruby 2.0 has released with exciting new features. But `khash` was removed, make this project no longer working. https://github.com/mruby/mruby/issues/4186

This patch is a proof of the concept in fixing the problem by rewriting the hash loop with features on the mruby `master` branch.

This patch may still not pass the CI. There are also breaking changes in mruby bytecode, so that the integration test should be further rewritten.