### PR TITLE
Remove unused dev.yml task

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,6 @@
 name: enterprise-script-service
 
 up:
-  - xcode_clt
   - ruby:
       version: 2.4.3
   - bundler


### PR DESCRIPTION
This dev.yml task is deprecated and does nothing, will be merging this on green.