### PR TITLE
Fix building mruby on macOS

### DIFF
--- a/ext/enterprise_script_service/flags.rb
+++ b/ext/enterprise_script_service/flags.rb
@@ -16,6 +16,11 @@ module Flags
       end
     end
 
+    def library_paths
+      # Necessary because of https://github.com/mruby/mruby/issues/4537
+      %w(/usr/local/lib /usr/lib)
+    end
+
     def io_safe_defines
       %w(
         _GNU_SOURCE

--- a/ext/enterprise_script_service/mruby_config.rb
+++ b/ext/enterprise_script_service/mruby_config.rb
@@ -2,6 +2,8 @@ require_relative("./flags")
 
 mruby_engine_gembox_path = Pathname.new(__FILE__).dirname.join("mruby_engine")
 
+# https://github.com/mruby/mruby/blob/master/doc/guides/compile.md
+
 MRuby::Build.new do |conf|
   toolchain(:gcc)
 
@@ -18,6 +20,10 @@ MRuby::Build.new do |conf|
     cc.flags += Flags.cflags
     cc.defines += Flags.io_safe_defines
   end
+
+  conf.linker do |linker|
+    linker.library_paths += Flags.library_paths
+  end
 end
 
 MRuby::CrossBuild.new("sandbox") do |conf|
@@ -33,5 +39,9 @@ MRuby::CrossBuild.new("sandbox") do |conf|
     cc.flags += %w(-fPIC)
     cc.flags += Flags.cflags
     cc.defines += Flags.defines
+  end
+
+  conf.linker do |linker|
+    linker.library_paths += Flags.library_paths
   end
 end


### PR DESCRIPTION
Add `/usr/local/lib` and `/usr/lib` to library paths to prevent a problem where the wrong version of `readline` gets linked.

This is a workaround for a problem being investigated upstream:
https://github.com/mruby/mruby/issues/4537

Fixes #37 
Depends on https://github.com/Shopify/ess/pull/39