### PR TITLE
Use bundler ~1.6 for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,10 @@ language: ruby
 rvm:
   - 2.4.4
 
+# https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+# We are still using bundler 1.17
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '~> 1.6'
+
 script: bundle exec rake compile


### PR DESCRIPTION
See https://docs.travis-ci.com/user/languages/ruby/#bundler-20

Fixes https://travis-ci.org/Shopify/ess/builds/551846677
```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.6)
  Current Bundler version:
    bundler (2.0.2)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
Could not find gem 'bundler (~> 1.6)' in any of the relevant sources:
  the local ruby installation
```