### PR TITLE
Update supported rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.4.4
-
-# https://docs.travis-ci.com/user/languages/ruby/#bundler-20
-# We are still using bundler 1.17
-before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '~> 1.6'
+  - 2.5.8
+  - 2.7.1
 
 script: bundle exec rake compile

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ name: enterprise-script-service
 
 up:
   - ruby:
-      version: 2.4.3
+      version: 2.5.8
   - bundler
   - submodules
 

--- a/enterprise_script_service.gemspec
+++ b/enterprise_script_service.gemspec
@@ -34,10 +34,10 @@ end
   spec.extensions = ["ext/enterprise_script_service/Rakefile"]
   spec.homepage = "https://github.com/Shopify/enterprise-script-service"
   spec.license = "MIT"
-  spec.required_ruby_version = '~> 2.2'
+  spec.required_ruby_version = '~> 2.5'
 
   spec.add_dependency("msgpack", "~> 1.0")
-  spec.add_development_dependency("bundler", "~> 1.6")
+  spec.add_development_dependency("bundler")
   spec.add_development_dependency("pry-byebug", "~> 3.4")
   spec.add_development_dependency("rake", "~> 11.3")
   spec.add_development_dependency("rake-compiler", "~> 0.9")

--- a/lib/enterprise_script_service/result.rb
+++ b/lib/enterprise_script_service/result.rb
@@ -1,9 +1,5 @@
 module EnterpriseScriptService
-  Result = Struct.new(:output, :stdout, :stat, :measurements, :errors) do
-    def initialize(output:, stdout:, stat:, measurements:, errors:)
-      super(output, stdout, stat, measurements, errors)
-    end
-
+  Result = Struct.new(:output, :stdout, :stat, :measurements, :errors, keyword_init: true) do
     def success?
       errors.empty?
     end


### PR DESCRIPTION
`Result#initialize` throws warnings on Ruby 2.7. It's kind of a Ruby bug (see: https://bugs.ruby-lang.org/issues/16801) but it's also easily worked around, so might as well fix it.

While I was at it I decided to update the list of supported rubies. Only 2.4.4 was tested, that ruby is very old. I chose to declare support for `~> 2.5` as older rubies are EOL.