### PR TITLE
Bump development gem & ruby versions

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,8 +1,8 @@
 apt-get update
 apt-get install -y build-essential zlib1g-dev libssl-dev libreadline6-dev libyaml-dev wget libffi-dev gcc g++ make bison libtool-bin autoconf
 cd `mktemp -d`
-curl -L "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.gz" | tar -xzf-
-cd ruby-2.3.3
+curl -L "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz" | tar -xzf-
+cd ruby-2.7.1
 ./configure --prefix=/usr/local
 make
 make install

--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,6 @@
 name: enterprise-script-service
 
 up:
-  - xcode_clt
   - ruby:
       version: 2.7.1
   - bundler

--- a/dev.yml
+++ b/dev.yml
@@ -3,8 +3,7 @@ name: enterprise-script-service
 up:
   - xcode_clt
   - ruby:
-      package: shopify/shopify/shopify-ruby
-      version: 2.2.3p172-shopify
+      version: 2.7.1
   - bundler
   - submodules
 

--- a/enterprise_script_service.gemspec
+++ b/enterprise_script_service.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_dependency("msgpack", "~> 1.0")
-  spec.add_development_dependency("bundler", "~> 1.6")
+  spec.add_development_dependency("bundler", "~> 2.1")
   spec.add_development_dependency("pry-byebug", "~> 3.4")
-  spec.add_development_dependency("rake", "~> 11.3")
+  spec.add_development_dependency("rake", "~> 13.0")
   spec.add_development_dependency("rake-compiler", "~> 0.9")
   spec.add_development_dependency("rspec", "~> 3.5")
 end


### PR DESCRIPTION
Theses gems were way out of date and causing issues in development. Also `2.2.3p172-shopify` no longer exists, so let's bump it to 2.7.1 where everything seems to work just fine using that version. 