### PR TITLE
Fix `dev compile` locally

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -10,15 +10,15 @@ commands:
   recompile:
     syntax: ""
     desc: "Compiles native extention"
-    run: bin/rake clobber compile
+    run: bundle exec rake clobber compile
   compile:
     syntax: ""
     desc: "Compiles native extention"
-    run: bin/rake compile
+    run: bundle exec rake compile
   spec:
     syntax: ""
     desc: "Run specs"
-    run: bin/rake spec
+    run: bundle exec rake spec
 
 packages:
   - git@github.com:Shopify/dev-shopify.git


### PR DESCRIPTION
For users that have their gems installed globally (using the default `path`), `dev compile`, `dev recompile`, and `dev spec` fail. This seems to be because the `bin/rake` script that was used attempts to load gems from two gem paths. By using bundler, only one gem library is used, which allows the tasks to be successfully started and run.

I sampled some repos within Shopify (e.g. core, partners, BP, etc.) and found that none of them use `rake` or `bin/rake` directly; they all invoke it through `bundle exec`. So it seems like we're being consistent here with what other repos do.

Closes https://github.com/Shopify/script-editor/issues/2320