### PR TITLE
Removed x86 assembler dependencies

### DIFF
--- a/ext/enterprise_script_service/mruby-mpdecimal/mrbgem.rake
+++ b/ext/enterprise_script_service/mruby-mpdecimal/mrbgem.rake
@@ -6,6 +6,6 @@ MRuby::Gem::Specification.new('mruby-mpdecimal') do |spec|
 
   spec.cc do
     cc.flags += %w(-Wno-declaration-after-statement)
-    cc.defines += %w(CONFIG_64 ASM HAVE_UINT128_T)
+    cc.defines += %w(CONFIG_64 ANSI HAVE_UINT128_T)
   end
 end

--- a/ext/enterprise_script_service/timer.cpp
+++ b/ext/enterprise_script_service/timer.cpp
@@ -1,30 +1,8 @@
 #include "timer.hpp"
 #include <cinttypes>
 
-static std::uint64_t read_time_stamp_counter() {
-  std::uint32_t low, high;
-  asm ("rdtsc" : "=a" (low), "=d" (high) :: "memory");
-  return (std::uint64_t{high} << 32) | low;
-}
-
-static std::uint64_t measure_cpu_time_scale() {
-  auto start_tick = read_time_stamp_counter();
-  auto start_time = std::chrono::high_resolution_clock::now();
-
-  std::uint64_t end_tick;
-  std::chrono::high_resolution_clock::time_point end_time;
-  std::chrono::nanoseconds diff;
-  do {
-    end_tick = read_time_stamp_counter();
-    end_time = std::chrono::high_resolution_clock::now();
-    diff = std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time);
-  } while (diff < std::chrono::microseconds{200});
-
-  return (end_tick - start_tick) / std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
-}
-
 timer::timer(std::function<void(const std::string, const std::int64_t)> writer) :
-    cpu_time_scale_(measure_cpu_time_scale()), writer(writer)
+  writer(writer)
 { }
 
 timer::scope timer::measure(const std::string name) const {
@@ -33,14 +11,13 @@ timer::scope timer::measure(const std::string name) const {
 }
 
 std::int64_t timer::scope::get_elapsed_time_us() {
-  auto now = read_time_stamp_counter();
-  return std::chrono::microseconds((now - base_) / cpu_time_scale_).count();
+  auto now = std::chrono::steady_clock::now();
+  return std::chrono::duration_cast<std::chrono::microseconds>(now - base_).count();
 }
 
 timer::scope::scope(const std::string name, const timer& t)
   : name_(name)
-  , cpu_time_scale_(t.cpu_time_scale_)
-  , base_(read_time_stamp_counter())
+  , base_(std::chrono::steady_clock::now())
   , writer_(t.writer)
 { }
 

--- a/ext/enterprise_script_service/timer.hpp
+++ b/ext/enterprise_script_service/timer.hpp
@@ -10,7 +10,6 @@ using cpu_time_scale = std::uint64_t;
 
 struct timer {
 
-  std::uint64_t cpu_time_scale_;
   std::function<void(const std::string, const std::int64_t)> writer;
 
   timer(std::function<void(const std::string, const std::int64_t)> writer);

--- a/ext/enterprise_script_service/timer.hpp
+++ b/ext/enterprise_script_service/timer.hpp
@@ -17,7 +17,7 @@ struct timer {
 
   struct scope {
     std::string name_;
-    std::uint64_t cpu_time_scale_, base_;
+    std::chrono::time_point<std::chrono::steady_clock> base_;
     std::function<void(const std::string, const std::int64_t)> writer_;
 
     std::int64_t get_elapsed_time_us();

--- a/tests/timer_test.cpp
+++ b/tests/timer_test.cpp
@@ -4,11 +4,6 @@
 #include "timer.hpp"
 #include "gtest/gtest.h"
 
-TEST(timer_test, measure_cpu_time_scale_on_init) {
-  timer t(nullptr);
-  EXPECT_GT(t.cpu_time_scale_, std::uint64_t{0});
-}
-
 TEST(timer_test, writes_output_once) {
   int invokes = 0;
   auto w = [&invokes](const std::string, const std::int64_t) {


### PR DESCRIPTION
This emoves x86 architecture dependencies to support ARM and M1 chips. This includes:
* use ANSI over ASM defines in mruby-mpdecimal
* switch to chrono::steady_clock instead of using `rdtsc` cpu reference cycles. 

Notably, the previous implementation of Timer counted the cpu cycles and then attempted to convert this to microseconds. This is problematic for a number of reasons, aside from being architecture dependent:
* didn't account for thread guarding and allowed the processor to re-order the execution
* didn't account for preemptive execution where the code moved to a different core (resulting in different values)
* didn't account for warm up, or performance variations by the processor
* didn't mark the assembler call as volatile, permitting the processor to cache the output

The net result is that the timings previously were likely under counting the performance of the sandboxed code.

Moving to chrono::steady_clock generally addresses these issues. However, there are other questions that should be evaluated such as whether the timing should be total clock time? Should it include kernel time? Just real time? Etc. These are questions that should be addressed in another context.