### PR TITLE
Allow futex

### DIFF
--- a/ext/enterprise_script_service/sandbox.cpp
+++ b/ext/enterprise_script_service/sandbox.cpp
@@ -16,6 +16,7 @@
 #include <sys/prctl.h>
 #include <sys/resource.h>
 #include <linux/seccomp.h>
+#include <linux/futex.h>
 
 void reserve_memory() {
   mallopt(M_TRIM_THRESHOLD, 64 * MiB);
@@ -47,6 +48,9 @@ void sandbox() {
   check_seccomp(seccomp_rule_add_exact(
     context, SCMP_ACT_ALLOW, SCMP_SYS(write), 1,
     SCMP_A0(SCMP_CMP_EQ, STDERR_FILENO)));
+  check_seccomp(seccomp_rule_add_exact(
+    context, SCMP_ACT_ALLOW, SCMP_SYS(futex), 1,
+    SCMP_A1(SCMP_CMP_EQ, FUTEX_WAKE_PRIVATE)));
 
   check_seccomp(seccomp_load(context));
   seccomp_release(context);


### PR DESCRIPTION
Full investigation in Shopify/script-editor#2962

We started seeing ESS crashes in production, with signal `SIGSYS`. We were able to reproduce on linux (in spin) by providing an invalid Ruby program, and saw that the offending syscall was `futex`. The sycall originates from libc when handling an exception – i.e. it happens between the `throw` and the `catch`.

This PR fixes that by allowing `futex FUTEX_WAKE_PRIVATE` sycalls. That works in our tests (we were able to unskip some tests that previously failed), and hopefully will also resolve our production issue.