### PR TITLE
Avoid using global allocator when unpacking input

### DIFF
--- a/ext/enterprise_script_service/script_data.cpp
+++ b/ext/enterprise_script_service/script_data.cpp
@@ -183,13 +183,11 @@ mrb_value msgpack_to_ruby(me_mruby_engine &engine, const msgpack::object &msgpac
     engine.check_exception();
     return ruby_value;
   } else if (msgpack_value.type == msgpack::type::STR) {
-    auto string_value = msgpack_value.as<std::string>();
-    auto ruby_value = mrb_str_new(engine.state, string_value.data(), string_value.size());
+    auto ruby_value = mrb_str_new(engine.state, msgpack_value.via.str.ptr, msgpack_value.via.str.size);
     engine.check_exception();
     return ruby_value;
   } else if (msgpack_value.type == msgpack::type::BIN) {
-    auto string_value = msgpack_value.as<std::vector<char>>();
-    auto ruby_value = mrb_str_new(engine.state, string_value.data(), string_value.size());
+    auto ruby_value = mrb_str_new(engine.state, msgpack_value.via.str.ptr, msgpack_value.via.str.size);
     engine.check_exception();
     return ruby_value;
   } else if (msgpack_value.type == msgpack::type::ARRAY) {

--- a/spec/script_service_spec.rb
+++ b/spec/script_service_spec.rb
@@ -254,4 +254,45 @@ RSpec.describe(EnterpriseScriptService) do
     expect(result.output).to eq(nil)
     expect(result.stdout).to eq("hello")
   end
+
+  it "accepts large inputs" do
+    result = EnterpriseScriptService.run(
+      input: "a" * 180 * 1024, # 180KiB
+      sources: [],
+      timeout: 1000,
+    )
+    expect(result.success?).to be(true)
+  end
+
+  it "fails gracefully when input is too large" do
+    result = EnterpriseScriptService.run(
+      input: "a" * 8 * 1024 * 1024, # 8MiB, total limit
+      sources: [],
+      timeout: 1000,
+    )
+    expect(result.success?).to be(false)
+    expect(result.errors).to eq([EnterpriseScriptService::EngineMemoryQuotaError.new])
+  end
+
+  it "roundtrips input with null bytes" do
+    assert_roundtrip_input("foo\0bar")
+  end
+
+  it "roundtrips emojis" do
+    assert_roundtrip_input("😅")
+  end
+
+  private
+
+  def assert_roundtrip_input(input)
+    result = EnterpriseScriptService.run(
+      input: input,
+      sources: [
+        ["foo", "@output = @input"],
+      ],
+      timeout: 1000,
+    )
+    expect(result.success?).to be(true)
+    expect(result.output).to eq(input)
+  end
 end


### PR DESCRIPTION
We SIGSYS on large inputs because we're calling `std::string` which uses the default allocator. This is an attempt at solving the SIGSYS by avoiding the allocation altogether.

We don't have to allocate a `std::string`: mruby copy the passed-in buffer immediately. mruby is configured to use a non-global allocator for which we've already allocated the maximum memory and is setup to not make additional syscalls.