### PR TITLE
Add GitHub Action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          bundler: latest
+          rubygems: 3.1.2
+
+      - name: Compile
+        run: bundle exec rake compile

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,10 @@ group :deployment do
   gem 'package_cloud'
   gem 'rake'
 end
+
+group :development do
+  # Newer versions don't work with Ruby 2.5 and 2.6
+  gem 'domain_name', '~> 0.5.20190701'
+  # Newer versions don't work with Ruby 2.5
+  gem 'thor', '~> 1.2.2'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,13 +10,14 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.1)
-    domain_name (0.6.20240107)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     highline (2.0.3)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     json_pure (2.3.1)
-    method_source (1.0.0)
+    method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0305)
@@ -28,12 +29,12 @@ GEM
       rainbow (= 2.2.2)
       rest-client (~> 2.0)
       thor (~> 1.2)
-    pry (0.14.2)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+      pry (~> 0.13.0)
     rainbow (2.2.2)
       rake
     rake (13.2.0)
@@ -57,19 +58,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    thor (1.3.1)
+    thor (1.2.2)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.9.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler
+  domain_name (~> 0.5.20190701)
   enterprise_script_service!
   package_cloud
-  pry-byebug (~> 3.4)
+  pry-byebug (~> 3.9.0)
   rake
   rake-compiler (~> 0.9)
   rspec (~> 3.5)
+  thor (~> 1.2.2)
 
 BUNDLED WITH
    2.5.7

--- a/enterprise_script_service.gemspec
+++ b/enterprise_script_service.gemspec
@@ -38,7 +38,8 @@ end
 
   spec.add_dependency("msgpack", "~> 1.0")
   spec.add_development_dependency("bundler")
-  spec.add_development_dependency("pry-byebug", "~> 3.4")
+  # Newer versions don't work with Ruby 2.5 and 2.6
+  spec.add_development_dependency("pry-byebug", "~> 3.9.0")
   spec.add_development_dependency("rake", "~> 11.3")
   spec.add_development_dependency("rake-compiler", "~> 0.9")
   spec.add_development_dependency("rspec", "~> 3.5")


### PR DESCRIPTION
Add a GitHub Action for continuous integration across several versions of Ruby.

We should consider dropping support for non-EOL versions of Ruby to remove some overrides I had to add. I also don't run the specs as part of this since we weren't in [the Travis version of CI](https://github.com/Shopify/ess/pull/57/files#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485). The specs don't appear to pass currently when I do try and run them.