### PR TITLE
Drop support for EOL Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,3 @@ group :deployment do
   gem 'package_cloud'
   gem 'rake'
 end
-
-group :development do
-  # Newer versions don't work with Ruby 2.5 and 2.6
-  gem 'domain_name', '~> 0.5.20190701'
-  # Newer versions don't work with Ruby 2.5
-  gem 'thor', '~> 1.2.2'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,12 +29,12 @@ GEM
       rainbow (= 2.2.2)
       rest-client (~> 2.0)
       thor (~> 1.2)
-    pry (0.13.1)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
+    pry-byebug (3.10.1)
       byebug (~> 11.0)
-      pry (~> 0.13.0)
+      pry (>= 0.13, < 0.15)
     rainbow (2.2.2)
       rake
     rake (13.2.0)
@@ -68,14 +68,12 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  domain_name (~> 0.5.20190701)
   enterprise_script_service!
   package_cloud
-  pry-byebug (~> 3.9.0)
+  pry-byebug (~> 3.9)
   rake
   rake-compiler (~> 0.9)
   rspec (~> 3.5)
-  thor (~> 1.2.2)
 
 BUNDLED WITH
    2.5.7

--- a/Rakefile
+++ b/Rakefile
@@ -9,11 +9,9 @@ end
 
 task(compile: []) do
   Dir.chdir("ext/enterprise_script_service") do
-    if RUBY_VERSION >= '2.7'
-      extra_args = []
-      extra_args << '' if RUBY_PLATFORM.match?(/darwin/i)
-      sh('sed', "-i", *extra_args, 's/{ :verbose => $verbose }/verbose: $verbose/', "mruby/Rakefile")
-    end
+    extra_args = []
+    extra_args << '' if RUBY_PLATFORM.match?(/darwin/i)
+    sh('sed', "-i", *extra_args, 's/{ :verbose => $verbose }/verbose: $verbose/', "mruby/Rakefile")
     sh("../../bin/rake")
   end
 end

--- a/enterprise_script_service.gemspec
+++ b/enterprise_script_service.gemspec
@@ -34,12 +34,11 @@ end
   spec.extensions = ["ext/enterprise_script_service/Rakefile"]
   spec.homepage = "https://github.com/Shopify/enterprise-script-service"
   spec.license = "MIT"
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_dependency("msgpack", "~> 1.0")
   spec.add_development_dependency("bundler")
-  # Newer versions don't work with Ruby 2.5 and 2.6
-  spec.add_development_dependency("pry-byebug", "~> 3.9.0")
+  spec.add_development_dependency("pry-byebug", "~> 3.9")
   spec.add_development_dependency("rake", "~> 11.3")
   spec.add_development_dependency("rake-compiler", "~> 0.9")
   spec.add_development_dependency("rspec", "~> 3.5")

--- a/ext/enterprise_script_service/Rakefile
+++ b/ext/enterprise_script_service/Rakefile
@@ -127,11 +127,9 @@ namespace(:mruby) do
 
   task(:compile) do
     within_mruby do
-      if RUBY_VERSION >= '2.7'
-        extra_args = []
-        extra_args << '' if RUBY_PLATFORM.match?(/darwin/i)
-        sh('sed', '-i', *extra_args, 's/{ :verbose => $verbose }/verbose: $verbose/', 'Rakefile')
-      end
+      extra_args = []
+      extra_args << '' if RUBY_PLATFORM.match?(/darwin/i)
+      sh('sed', '-i', *extra_args, 's/{ :verbose => $verbose }/verbose: $verbose/', 'Rakefile')
       sh("ruby", "./minirake")
     end
   end


### PR DESCRIPTION
We were support Ruby 2.5 and up. However a number of our dependencies dropped support for Ruby versions less than 2.7. As well, if we're intending to run Dependabot to keep dependencies up-to-date, we should expect this to happen more often.

This drops support for Ruby 2.5, Ruby 2.6, Ruby 2.7, and Ruby 3.0 since they are marked as end-of-life (EOL) on https://www.ruby-lang.org/en/downloads/branches/.