### PR TITLE
Fixes to support Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} / ${{ matrix.os }}
     strategy:
       matrix:
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        os: ["ubuntu-22.04", "ubuntu-24.04"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (11.1.3)
-    coderay (1.1.3)
     diff-lcs (1.5.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -17,7 +15,6 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     json_pure (2.3.1)
-    method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0305)
@@ -29,12 +26,6 @@ GEM
       rainbow (= 2.2.2)
       rest-client (~> 2.0)
       thor (~> 1.2)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     rainbow (2.2.2)
       rake
     rake (13.2.1)
@@ -71,7 +62,6 @@ DEPENDENCIES
   domain_name (~> 0.5.20190701)
   enterprise_script_service!
   package_cloud
-  pry-byebug (~> 3.9.0)
   rake
   rake-compiler (~> 0.9)
   rspec (~> 3.5)

--- a/enterprise_script_service.gemspec
+++ b/enterprise_script_service.gemspec
@@ -39,7 +39,6 @@ end
   spec.add_dependency("msgpack", "~> 1.0")
   spec.add_development_dependency("bundler")
   # Newer versions don't work with Ruby 2.5 and 2.6
-  spec.add_development_dependency("pry-byebug", "~> 3.9.0")
   spec.add_development_dependency("rake", "~> 13.2")
   spec.add_development_dependency("rake-compiler", "~> 0.9")
   spec.add_development_dependency("rspec", "~> 3.5")

--- a/ext/enterprise_script_service/error.hpp
+++ b/ext/enterprise_script_service/error.hpp
@@ -1,6 +1,7 @@
 #ifndef ENTERPRISE_SCRIPT_SERVICE_ERROR_HPP
 #define ENTERPRISE_SCRIPT_SERVICE_ERROR_HPP
 
+#include <cstdint>
 #include <exception>
 #include "data.hpp"
 

--- a/ext/enterprise_script_service/options.hpp
+++ b/ext/enterprise_script_service/options.hpp
@@ -2,6 +2,7 @@
 #define ENTERPRISE_SCRIPT_SERVICE_OPTIONS_HPP
 
 #include <ctype.h>
+#include <cstdint>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/spec/script_service_spec.rb
+++ b/spec/script_service_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe(EnterpriseScriptService) do
 
     error = result.errors[0]
     expect(error).to be_an(EnterpriseScriptService::EngineSyntaxError)
-    expect(error.message).to eq("syntax_error.rb:1:3: syntax error, unexpected keyword_end")
+    expect(error.message).to include("syntax_error.rb:1:3: syntax error")
     expect(error.filename).to eq("syntax_error.rb")
     expect(error.line_number).to eq(1)
     expect(error.column).to eq(3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require("enterprise_script_service")
-require("pry")
 
 RSpec.configure do |config|
   config.expect_with(:rspec) do |expectations|

--- a/tests/data_writer_test.cpp
+++ b/tests/data_writer_test.cpp
@@ -29,7 +29,7 @@ TEST(data_writer_test, outputs_measurements) {
 
   char output[BUFSIZE];
   ssize_t r, in = 0;
-  while ((r = read(fd[0], &output + in, (size_t) (BUFSIZE - in))) > 0) {
+  while ((r = read(fd[0], output + in, (size_t) (BUFSIZE - in))) > 0) {
     if ((in += r) >= BUFSIZE) break;
   }
   close(fd[0]);

--- a/tests/integration_test.cpp
+++ b/tests/integration_test.cpp
@@ -48,9 +48,9 @@ TEST(integration_test, happy_path) {
   char output[BUFSIZE];
   msgpack::unpacker pac;
   ssize_t r, in = 0;
-  while ((r = read(fd[0], &output + in, (size_t) (BUFSIZE - in))) > 0) {
+  while ((r = read(fd[0], output + in, (size_t) (BUFSIZE - in))) > 0) {
     pac.reserve_buffer(r);
-    memcpy(pac.buffer(), &output + in, r);
+    memcpy(pac.buffer(), output + in, r);
     pac.buffer_consumed(r);
   }
 

--- a/tests/mruby_data_writer_test.cpp
+++ b/tests/mruby_data_writer_test.cpp
@@ -32,7 +32,7 @@ TEST(mruby_data_writer_test, outputs_valid_data) {
 
   char output[BUFSIZE];
   ssize_t r, in = 0;
-  while ((r = read(fd[0], &output + in, (size_t) (BUFSIZE - in))) > 0) {
+  while ((r = read(fd[0], output + in, (size_t) (BUFSIZE - in))) > 0) {
     if ((in += r) >= BUFSIZE) break;
   }
 
@@ -105,7 +105,7 @@ TEST(mruby_data_writer_test, throws_on_too_deep_stack) {
 
   char output[BUFSIZE];
   ssize_t r, in = 0;
-  while ((r = read(fd[0], &output + in, (size_t) (BUFSIZE - in))) > 0) {
+  while ((r = read(fd[0], output + in, (size_t) (BUFSIZE - in))) > 0) {
     if ((in += r) >= BUFSIZE) break;
   }
 
@@ -143,7 +143,7 @@ TEST(mruby_data_writer_test, extracts_data) {
 
   char output[BUFSIZE];
   ssize_t r, in = 0;
-  while ((r = read(fd[0], &output + in, (size_t) (BUFSIZE - in))) > 0) {
+  while ((r = read(fd[0], output + in, (size_t) (BUFSIZE - in))) > 0) {
     if ((in += r) >= BUFSIZE) break;
   }
 
@@ -210,7 +210,7 @@ TEST(mruby_data_writer_test, emits_stat) {
 
   char output[BUFSIZE];
   ssize_t r, in = 0;
-  while ((r = read(fd[0], &output + in, (size_t) (BUFSIZE - in))) > 0) {
+  while ((r = read(fd[0], output + in, (size_t) (BUFSIZE - in))) > 0) {
     if ((in += r) >= BUFSIZE) break;
   }
 

--- a/tests/script_runner_test.cpp
+++ b/tests/script_runner_test.cpp
@@ -104,7 +104,7 @@ TEST(script_runner_test, runs_all_scripts) {
 
   char output[BUFSIZE];
   ssize_t r, in = 0;
-  while ((r = read(fd[0], &output + in, (size_t) (BUFSIZE - in))) > 0) {
+  while ((r = read(fd[0], output + in, (size_t) (BUFSIZE - in))) > 0) {
     if ((in += r) >= BUFSIZE) break;
   }
 


### PR DESCRIPTION
There's a bunch of things to unpack in this PR so I'll go over some details.

- Updating the CI workflow to test on both Ubuntu 22.04 and Ubuntu 24.04
- Removing `pry-byebug` because it was giving me a headache and we don't really use it. If someone really wants it, they can figure out how to get it working and add it back. This covers `Gemfile`, `Gemfile.lock`, and `spec_helper.rb`.
- Fix a test result where there was a slight change to the error message
- Include a header that was implicitly included before but is no longer implicitly included
- Fix some potential buffer overflows in the tests. These potential buffer overflows are not located outside of the tests.

For details on the change to the tests, GCC added a new fortification level (level 3) in May 2022 intended to discover buffer overflows. This new fortification level introduced checks into `read` that would abort the process if the number of bytes being read would exceed the size of the buffer the bytes are read into (determined by using `__builtin_dynamic_object_size`). This was introduced after Ubuntu 22.04 released so it did not include a version of GCC that performs these checks, but Ubuntu 24.04 does include a version that performs these checks, so that's why the tests pass on Ubuntu 22.04 and not Ubuntu 24.04. I don't know how or why fortification is being applied to the code for the tests given I can't find a place where we're defining the `FORTIFY_SOURCE` macro. In any case, closely examining the code where we are calling `read`, I can confirm there's a potential for a buffer overflow, so fixing that potential buffer overflow seems like the ideal solution and is trivial.

As for why the existing read operation has a potential buffer overflow, let's look at the output of the following program:

```c
int main()
{
    char output[1024];
    fprintf(stdout, "%p\n", &output);
    fprintf(stdout, "%p\n", &output + 1);
    fprintf(stdout, "%p\n", output);
    fprintf(stdout, "%p\n", output + 1);
    return 0;
}
```

Outputs something like:

```
0x7fff666890b0
0x7fff666894b0
0x7fff666890b0
0x7fff666890b1
```

Notice that:
- both `output` and `&output` have the same address
- adding `1` to `&output` results in 0x400 (or 1024 in decimal) being added to `output`'s address
- adding `1` to `output` results in 0x1 being added to `output`'s address

So, if `in` in the test cases were set to `23`, the destination address to write what was read off of the buffer would be set to 0x5C00 after the start of `output` (or 0x5800 after the end of the output buffer).

The tests all only iterate through calling `read` once so they never actually wrote into memory they shouldn't have which is another reason this had not surfaced before.