### PR TITLE
Support Nix-provided GNU sed on macOS

### DIFF
--- a/ext/enterprise_script_service/Rakefile
+++ b/ext/enterprise_script_service/Rakefile
@@ -193,7 +193,8 @@ namespace(:mruby) do
   task(:compile_no_gen_gc) do
     within_mruby(config: '../mruby_no_gen_gc_config.rb') do
       extra_args = []
-      extra_args << '' if RUBY_PLATFORM.match?(/darwin/i)
+      is_bsd_sed = RUBY_PLATFORM.match?(/darwin/i) && !ENV.key?('NIX_CC')
+      extra_args << '' if is_bsd_sed
       sh('sed', '-i', *extra_args, 's/{ :verbose => $verbose }/verbose: $verbose/', 'Rakefile')
       sh("ruby", "./minirake")
     end


### PR DESCRIPTION
Nix provides GNU sed as "sed" on both macOS and Linux. We could attempt to detect GNU sed by checking the output / exit code of sed --version, but Homebrew provides GNU sed as "gsed"[1], so aside from when folks are using Nix, I don't think this is a case we'll realistically encounter on macOS.
    
[1] https://formulae.brew.sh/formula/gnu-sed
