### PR TITLE
Remove unnecessary execution_time_us assertions

### DIFF
--- a/tests/script_runner_test.cpp
+++ b/tests/script_runner_test.cpp
@@ -32,12 +32,10 @@ TEST(script_runner_test, defaults_to_counting_all_instructions) {
   close(fd[1]);
   auto instruction_total = engine->instruction_total;
   auto instruction_count = engine->instruction_count;
-  auto execution_time_us = engine->execution_time_us;
   me_mruby_engine_destroy(engine);
   me_memory_pool_destroy(allocator);
   close(fd[0]);
   EXPECT_EQ(instruction_total, instruction_count);
-  EXPECT_EQ(execution_time_us, std::int64_t{0});
 }
 
 TEST(script_runner_test, can_bypass_deserialization_instructions) {
@@ -65,13 +63,11 @@ TEST(script_runner_test, can_bypass_deserialization_instructions) {
   close(fd[1]);
   auto instruction_total = engine->instruction_total;
   auto instruction_count = engine->instruction_count;
-  auto execution_time_us = engine->execution_time_us;
   me_mruby_engine_destroy(engine);
   me_memory_pool_destroy(allocator);
   close(fd[0]);
   EXPECT_LT(instruction_count, instruction_total);
   EXPECT_EQ(instruction_count, std::uint64_t{3});
-  EXPECT_EQ(execution_time_us, std::int64_t{0});
 }
 
 TEST(script_runner_test, runs_all_scripts) {


### PR DESCRIPTION
Fixes https://github.com/shop/issues-shopifyvm/issues/844

In a recent build, we noticed that there was a failure in the `defaults_to_counting_all_instructions` test due to `execution_time_us` being 3 instead of 0. This assertion doesn't make sense for this test since the test is about instruction counts. It also doesn't add value to check that it's >= 0, since that's a guarantee for a `uint64`.

I've also removed this assertion in `can_bypass_deserialization_instructions` for a similar reason.