### PR TITLE
Fixes for NixOS 25.11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "mruby"]
 	path = ext/enterprise_script_service/mruby
-	url = https://github.com/mruby/mruby.git
-	branch = master
+	url = https://github.com/Shopify/mruby.git
+	branch = jringer/better-distinguish-clang
 [submodule "msgpack"]
 	path = ext/enterprise_script_service/msgpack
 	url = https://github.com/msgpack/msgpack-c.git

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source("https://rubygems.org")
 
 gemspec
+gem 'getoptlong'
 group :deployment do
   gem 'package_cloud'
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
     diff-lcs (1.5.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    getoptlong (0.2.1)
     highline (2.0.3)
     http-accept (1.7.0)
     http-cookie (1.0.5)
@@ -60,6 +61,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   enterprise_script_service!
+  getoptlong
   package_cloud
   rake
   rake-compiler (~> 0.9)

--- a/Rakefile
+++ b/Rakefile
@@ -9,9 +9,10 @@ end
 
 task(compile: []) do
   Dir.chdir("ext/enterprise_script_service") do
-    extra_args = []
-    extra_args << '' if RUBY_PLATFORM.match?(/darwin/i)
-    sh('sed', "-i", *extra_args, 's/{ :verbose => $verbose }/verbose: $verbose/', "mruby/Rakefile")
+    mruby_rakefile = "mruby/Rakefile"
+    content = File.read(mruby_rakefile)
+    content.gsub!('{ :verbose => $verbose }', 'verbose: $verbose')
+    File.write(mruby_rakefile, content)
     sh("../../bin/rake")
   end
 end

--- a/ext/enterprise_script_service/Rakefile
+++ b/ext/enterprise_script_service/Rakefile
@@ -127,9 +127,9 @@ namespace(:mruby) do
 
   task(:compile) do
     within_mruby do
-      extra_args = []
-      extra_args << '' if RUBY_PLATFORM.match?(/darwin/i)
-      sh('sed', '-i', *extra_args, 's/{ :verbose => $verbose }/verbose: $verbose/', 'Rakefile')
+      content = File.read('Rakefile')
+      content.gsub!('{ :verbose => $verbose }', 'verbose: $verbose')
+      File.write('Rakefile', content)
       sh("ruby", "./minirake")
     end
   end

--- a/ext/enterprise_script_service/mruby_config.rb
+++ b/ext/enterprise_script_service/mruby_config.rb
@@ -22,6 +22,7 @@ MRuby::Build.new do |conf|
   end
 
   conf.linker do |linker|
+    linker.command = conf.cc.command
     linker.library_paths += Flags.library_paths
   end
 end
@@ -42,6 +43,7 @@ MRuby::CrossBuild.new("sandbox") do |conf|
   end
 
   conf.linker do |linker|
+    linker.command = conf.cc.command
     linker.library_paths += Flags.library_paths
   end
 end


### PR DESCRIPTION
Nix provides GNU coreutils, so BSD-style sed usage fails. Similarly, Nix uses a wrapped compiler to do linking which is aware of paths such as libc and libstdc++, whereas `ld` is not.