### PR TITLE
NixOS 25.11 fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "ext/enterprise_script_service/mruby"]
 	path = ext/enterprise_script_service/mruby
 	url = https://github.com/Shopify/mruby.git
-	branch = mruby-engine-submodule
+	branch = jringer/better-distinguish-clang
 [submodule "msgpack"]
 	path = ext/enterprise_script_service/msgpack
 	url = https://github.com/msgpack/msgpack-c.git

--- a/ext/enterprise_script_service/Rakefile
+++ b/ext/enterprise_script_service/Rakefile
@@ -192,10 +192,9 @@ namespace(:mruby) do
 
   task(:compile_no_gen_gc) do
     within_mruby(config: '../mruby_no_gen_gc_config.rb') do
-      extra_args = []
-      is_bsd_sed = RUBY_PLATFORM.match?(/darwin/i) && !ENV.key?('NIX_CC')
-      extra_args << '' if is_bsd_sed
-      sh('sed', '-i', *extra_args, 's/{ :verbose => $verbose }/verbose: $verbose/', 'Rakefile')
+      content = File.read('Rakefile')
+      content.gsub!('{ :verbose => $verbose }', 'verbose: $verbose')
+      File.write('Rakefile', content)
       sh("ruby", "./minirake")
     end
   end

--- a/ext/enterprise_script_service/mruby_shared_config.rb
+++ b/ext/enterprise_script_service/mruby_shared_config.rb
@@ -19,6 +19,10 @@ def build(defines)
       cc.flags += Flags.cflags
       cc.defines += defines
     end
+
+    conf.linker do |linker|
+      linker.command = conf.cc.command
+    end
   end
 end
 
@@ -36,6 +40,10 @@ def crossbuild(directory, defines)
       cc.flags += %w(-fPIC)
       cc.flags += Flags.cflags
       cc.defines += defines
+    end
+
+    conf.linker do |linker|
+      linker.command = conf.cc.command
     end
   end
 end


### PR DESCRIPTION
https://github.com/Shopify/ess/pull/98, but rebased for `shopify-core-version` branch